### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The real difference begins when you turn the EventMachine reactor on.
     Fiber.new do
       pg.query('select * from foo') do |result|
         puts Array(result).inspect
+        EM.stop
       end
-      EM.stop
     end.resume
   end
 


### PR DESCRIPTION
Since `pg.query` is async here, `EM.stop` is called before the result callback, it makes the program print nothing and exit immediately.
